### PR TITLE
feat(ux): animations, responsive fixes, and layout polish

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "eljamez-dev",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "dev"],
+      "port": 3000
+    }
+  ]
+}

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,3 +1,4 @@
+import FadeInSection from "@/components/FadeInSection";
 import PageSubheader from "@/components/PageSubheader";
 import TextContainer from "@/components/TextContainer";
 import Image from "next/image";
@@ -22,47 +23,51 @@ export default function AboutPage() {
         <PageHeader title="About Me" />
       </section> */}
       {/* Bio Section */}
-      <section className="flex flex-col gap-8 items-center justify-center w-full sm:w-1/3 mx-auto">
-        <div className="flex-shrink-0">
-          <Image
-            src="/profile.png" // Place your photo in public/profile.png
-            alt="James Augustus Hall"
-            width={160}
-            height={160}
-            className="rounded-full drop-shadow-hero border-4 border-accent"
-            priority
-          />
-        </div>
-        <PageSubheader title="James Augustus Hall" />
-        <TextContainer className="flex flex-col gap-4">
-          <p className="text-center">
-            I&apos;m a Senior Software Engineer. I like to make apps that people
-            like to use, with a focus on clean maintainable code and user
-            experience. I&apos;m based in Ojai, CA.
-          </p>
-        </TextContainer>
-      </section>
-      <section className="mt-10 flex flex-col gap-6 items-center justify-center">
-        <PageSubheader title="Skills" />
-        <div className="w-full sm:w-2/3 px-10">
-          <ul className="flex flex-wrap w-full justify-center items-center gap-2">
-            <SkillPill skill="React" icon={<SiReact size={24} />} />
-            <SkillPill skill="Next.js" icon={<SiNextdotjs size={24} />} />
-            <SkillPill skill="TypeScript" icon={<SiTypescript size={24} />} />
-            <SkillPill skill="Vue.js" icon={<SiVuedotjs size={24} />} />
-            <SkillPill skill="Svelte" icon={<SiSvelte size={24} />} />
-            <SkillPill skill="Node.js" icon={<SiNodedotjs size={24} />} />
-            <SkillPill skill="Python" icon={<SiPython size={24} />} />
-            <SkillPill skill="Git" icon={<SiGit size={24} />} />
-            <SkillPill skill="Prisma" icon={<SiPrisma size={24} />} />
-            <SkillPill skill="PostgreSQL" icon={<SiPostgresql size={24} />} />
-            <SkillPill
-              skill="Tailwind CSS"
-              icon={<SiTailwindcss size={24} />}
+      <FadeInSection>
+        <section className="flex flex-col gap-8 items-center justify-center w-full sm:w-1/3 mx-auto">
+          <div className="flex-shrink-0">
+            <Image
+              src="/profile.png" // Place your photo in public/profile.png
+              alt="James Augustus Hall"
+              width={160}
+              height={160}
+              className="rounded-full drop-shadow-hero border-4 border-accent"
+              priority
             />
-          </ul>
-        </div>
-      </section>
+          </div>
+          <PageSubheader title="James Augustus Hall" />
+          <TextContainer className="flex flex-col gap-4">
+            <p className="text-center">
+              I&apos;m a Senior Software Engineer. I like to make apps that people
+              like to use, with a focus on clean maintainable code and user
+              experience. I&apos;m based in Ojai, CA.
+            </p>
+          </TextContainer>
+        </section>
+      </FadeInSection>
+      <FadeInSection delay="150ms">
+        <section className="mt-10 flex flex-col gap-6 items-center justify-center">
+          <PageSubheader title="Skills" />
+          <div className="w-full sm:w-2/3 px-10">
+            <ul className="flex flex-wrap w-full justify-center items-center gap-2">
+              <SkillPill skill="React" icon={<SiReact size={24} />} />
+              <SkillPill skill="Next.js" icon={<SiNextdotjs size={24} />} />
+              <SkillPill skill="TypeScript" icon={<SiTypescript size={24} />} />
+              <SkillPill skill="Vue.js" icon={<SiVuedotjs size={24} />} />
+              <SkillPill skill="Svelte" icon={<SiSvelte size={24} />} />
+              <SkillPill skill="Node.js" icon={<SiNodedotjs size={24} />} />
+              <SkillPill skill="Python" icon={<SiPython size={24} />} />
+              <SkillPill skill="Git" icon={<SiGit size={24} />} />
+              <SkillPill skill="Prisma" icon={<SiPrisma size={24} />} />
+              <SkillPill skill="PostgreSQL" icon={<SiPostgresql size={24} />} />
+              <SkillPill
+                skill="Tailwind CSS"
+                icon={<SiTailwindcss size={24} />}
+              />
+            </ul>
+          </div>
+        </section>
+      </FadeInSection>
 
       {/* <section className="flex justify-center gap-6 my-4">
         <Link
@@ -78,7 +83,7 @@ export default function AboutPage() {
 
 function SkillPill({ skill, icon }: { skill: string; icon: React.ReactNode }) {
   return (
-    <li className="bg-accent text-white rounded-md p-2 flex items-center gap-2">
+    <li className="bg-accent text-white rounded-md p-2 flex items-center gap-2 transition-all duration-200 hover:scale-105 hover:shadow-md hover:bg-zinc-600 cursor-default">
       {icon}
       <span className="font-bold">{skill}</span>
     </li>

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 import PageHeader from "@/components/PageHeader";
 import TextContainer from "@/components/TextContainer";
+import { Loader2 } from "lucide-react";
 import { useState } from "react";
 
 // Contact page for sending messages via Resend
@@ -85,19 +86,26 @@ export default function ContactPage() {
           />
           <button
             type="submit"
-            className="bg-secondary hover:scale-105 transition-all text-zinc-900 font-bold py-3 rounded hover:bg-secondary disabled:opacity-60"
+            className="bg-secondary hover:scale-105 transition-all text-zinc-900 font-bold py-3 rounded hover:bg-secondary disabled:opacity-60 flex items-center justify-center gap-2"
             disabled={status === "loading"}
           >
-            {status === "loading" ? "Sending..." : "Send Message"}
+            {status === "loading" ? (
+              <>
+                <Loader2 size={18} className="animate-spin" />
+                Sending...
+              </>
+            ) : (
+              "Send Message"
+            )}
           </button>
         </form>
         {status === "success" && (
-          <TextContainer className="mt-4 text-slate-100 border-1 border-green-500 font-bold">
+          <TextContainer className="mt-4 text-slate-100 border-1 border-green-500 font-bold animate-scale-in">
             Thank you! Your message has been sent.
           </TextContainer>
         )}
         {status === "error" && (
-          <p className="mt-4 text-red-400 font-bold">
+          <p className="mt-4 text-red-400 font-bold animate-shake">
             Oops! Something went wrong. Please try again.
           </p>
         )}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -28,6 +28,15 @@ main {
   } */
 }
 
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+
 @layer utilities {
   .text-balance {
     text-wrap: balance;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -82,8 +82,7 @@ export default function RootLayout({
         <main
           className={`${merriweather.variable} ${zillaSlab.variable} font-serif gap-0 min-h-screen text-primary`}
         >
-          {/* <Header /> */}
-          <div className="flex flex-col sm:h-auto flex-1">{children}</div>
+            <div className="flex flex-col sm:h-auto flex-1">{children}</div>
         </main>
       </body>
     </html>

--- a/src/app/work/page.tsx
+++ b/src/app/work/page.tsx
@@ -1,3 +1,4 @@
+import FadeInSection from "@/components/FadeInSection";
 import PageHeader from "@/components/PageHeader";
 import PageSubheader from "@/components/PageSubheader";
 import ProjectCard from "@/components/ProjectCard";
@@ -35,22 +36,26 @@ export default function WorkPage() {
       <section className="mb-8">
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 md:gap-20 items-stretch">
           {projects.map((project: Project, idx: number) => (
-            <ProjectCard key={idx} project={project} />
+            <FadeInSection key={idx} delay={`${idx * 120}ms`}>
+              <ProjectCard project={project} />
+            </FadeInSection>
           ))}
         </div>
       </section>
 
       <PageSubheader title="Past Client Work" />
       {/* Past Client Work Section */}
-      <TextContainer className="mt-8 text-lg sm:w-1/2">
-        <ul className="list-disc list-inside leading-relaxed">
-          {pastWork.map((work: PastWork, idx: number) => (
-            <li key={idx} className="drop-shadow-hero">
-              {work.client} – {work.project}
-            </li>
-          ))}
-        </ul>
-      </TextContainer>
+      <FadeInSection>
+        <TextContainer className="mt-8 text-lg sm:w-1/2">
+          <ul className="list-disc list-inside leading-relaxed">
+            {pastWork.map((work: PastWork, idx: number) => (
+              <li key={idx} className="drop-shadow-hero">
+                {work.client} – {work.project}
+              </li>
+            ))}
+          </ul>
+        </TextContainer>
+      </FadeInSection>
     </div>
   );
 }

--- a/src/components/FadeInSection.tsx
+++ b/src/components/FadeInSection.tsx
@@ -5,9 +5,11 @@ import { useEffect, useRef, useState } from "react";
 export default function FadeInSection({
   children,
   className = "",
+  delay = "0ms",
 }: {
   children: React.ReactNode;
   className?: string;
+  delay?: string;
 }) {
   const ref = useRef<HTMLDivElement>(null);
   const [isVisible, setIsVisible] = useState(false);
@@ -31,6 +33,7 @@ export default function FadeInSection({
   return (
     <div
       ref={ref}
+      style={{ transitionDelay: delay }}
       className={cx(
         "transition-all duration-1000 motion-safe:opacity-0 motion-safe:translate-y-8", // initial state
         isVisible ? "motion-safe:opacity-100 motion-safe:translate-y-0" : "", // fade in

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -83,13 +83,13 @@ export const Header = () => {
     <>
       <nav
         className={`fixed top-0 z-50 w-full p-4 sm:py-4 sm:px-8 flex justify-between items-center group transition-all duration-300 ${
-          scrolled ? "bg-white/20 backdrop-blur" : "bg-transparent"
+          scrolled ? "bg-white/20 backdrop-blur shadow-sm" : "bg-gradient-to-b from-black/30 to-transparent"
         }`}
         onMouseEnter={() => {
           setRotation(Math.floor(Math.random() * rotations.length));
         }}
       >
-        <Link className="flex text-3xl sm:text-5xl text-primary" href="/">
+        <Link className={`flex text-3xl sm:text-5xl transition-colors duration-300 ${scrolled ? "text-primary" : "text-white"}`} href="/">
           <p className="flex flex-1 transition-all ease-in-out font-oswald font-bold tracking-tighter uppercase">
             {logoLetters.map((item, i) => (
               <span
@@ -107,13 +107,13 @@ export const Header = () => {
           onClick={() => setMobileMenuOpen((v) => !v)}
         >
           <span
-            className={`block w-6 h-0.5 bg-primary mb-1 transition-all ${mobileMenuOpen ? "rotate-45 translate-y-2" : ""}`}
+            className={`block w-6 h-0.5 mb-1 transition-all ${scrolled ? "bg-primary" : "bg-white"} ${mobileMenuOpen ? "rotate-45 translate-y-2" : ""}`}
           ></span>
           <span
-            className={`block w-6 h-0.5 bg-primary mb-1 transition-all ${mobileMenuOpen ? "opacity-0" : ""}`}
+            className={`block w-6 h-0.5 mb-1 transition-all ${scrolled ? "bg-primary" : "bg-white"} ${mobileMenuOpen ? "opacity-0" : ""}`}
           ></span>
           <span
-            className={`block w-6 h-0.5 bg-primary transition-all ${mobileMenuOpen ? "-rotate-45 -translate-y-2" : ""}`}
+            className={`block w-6 h-0.5 transition-all ${scrolled ? "bg-primary" : "bg-white"} ${mobileMenuOpen ? "-rotate-45 -translate-y-2" : ""}`}
           ></span>
         </button>
         <div className="hidden sm:flex items-center gap-6">
@@ -129,8 +129,8 @@ export const Header = () => {
                     link.isButton
                       ? "ml-2 px-4 py-2 bg-accent text-white hover:shadow-lg font-bold rounded-lg shadow-card hover:text-slate-600 hover:bg-secondary transition-all hover:scale-110 text-base sm:text-lg"
                       : link.href === pathname
-                        ? "text-accent font-oswald"
-                        : "hover:text-accent transition-all font-oswald"
+                        ? `font-oswald ${scrolled ? "text-accent" : "text-white"}`
+                        : `font-oswald transition-all ${scrolled ? "text-primary hover:text-accent" : "text-white/80 hover:text-white"}`
                   }
                 >
                   {link.text}

--- a/src/components/ProjectCard.tsx
+++ b/src/components/ProjectCard.tsx
@@ -10,20 +10,22 @@ interface ProjectCardProps {
 
 export default function ProjectCard({ project }: ProjectCardProps) {
   return (
-    <div className="h-full bg-blend-saturation bg-slate-100 rounded-lg p-0 shadow overflow-hidden transform transition-all duration-300 min-h-[320px] sm:min-h-[420px] flex w-full sm:w-1/3 flex-shrink-0 max-sm:h-[50vh]">
-      <div className="w-20 bg-zinc-800 flex items-center justify-center">
+    <div className="group h-full bg-blend-saturation bg-slate-100 rounded-lg p-0 shadow overflow-hidden transform transition-all duration-300 hover:scale-[1.02] hover:shadow-xl min-h-[320px] sm:min-h-[420px] flex w-full sm:w-1/3 flex-shrink-0 max-sm:h-[50vh]">
+      <div className="w-20 bg-zinc-800 group-hover:bg-zinc-700 transition-colors duration-300 flex items-center justify-center">
         <h3 className="text-xl -rotate-90 sm:text-5xl font-bold text-zinc-100 mt-10 whitespace-nowrap">
           {project.title}
         </h3>
       </div>
-      <div className="flex-1 flex flex-col items-center justify-center">
-        <Image
-          src={project.image}
-          alt={project.title}
-          width={500}
-          height={500}
-          className="w-full flex-1 min-h-40 sm:h-40 object-cover object-top"
-        />
+      <div className="flex-1 flex flex-col items-center justify-center overflow-hidden">
+        <div className="w-full overflow-hidden flex-1 min-h-40 sm:h-40">
+          <Image
+            src={project.image}
+            alt={project.title}
+            width={500}
+            height={500}
+            className="w-full h-full object-cover object-top transition-transform duration-500 group-hover:scale-110"
+          />
+        </div>
         <div className="p-3 sm:p-5 flex flex-col gap-6 h-full flex-1 text-center">
           <span className="text-sm sm:text-base text-zinc-600 mb-2 font-silkscreen tracking-wide max-sm:hidden">
             {project.employer}

--- a/src/components/home/HomePage4.tsx
+++ b/src/components/home/HomePage4.tsx
@@ -3,12 +3,6 @@ import { BsSubstack } from "react-icons/bs";
 import { FaCodepen, FaGithub, FaLinkedin, FaSoundcloud } from "react-icons/fa";
 
 const links = [
-  //   {
-  //     href: "https://bleepsandbloops.com",
-  //     text: "Bleeps and Bloops",
-  //     icon: <Code />,
-  //     description: "Apps and Tools and Things I Make",
-  //   },
   {
     href: "https://whatsoever.biz",
     text: "Whatsoever",
@@ -30,76 +24,68 @@ const links = [
 ];
 
 const socialLinks = [
-  {
-    href: "https://github.com/eljamez",
-    text: "GitHub",
-    icon: <FaGithub />,
-  },
-  {
-    href: "https://www.linkedin.com/in/eljamez/",
-    text: "LinkedIn",
-    icon: <FaLinkedin />,
-  },
-  {
-    href: "https://substack.com/@jamesaugustushall",
-    text: "Substack",
-    icon: <BsSubstack />,
-  },
-  {
-    href: "https://codepen.io/eljamez",
-    text: "CodePen",
-    icon: <FaCodepen />,
-  },
-  {
-    href: "https://soundcloud.com/eljamez",
-    text: "SoundCloud",
-    icon: <FaSoundcloud />,
-  },
+  { href: "https://github.com/eljamez", text: "GitHub", icon: <FaGithub /> },
+  { href: "https://www.linkedin.com/in/eljamez/", text: "LinkedIn", icon: <FaLinkedin /> },
+  { href: "https://substack.com/@jamesaugustushall", text: "Substack", icon: <BsSubstack /> },
+  { href: "https://codepen.io/eljamez", text: "CodePen", icon: <FaCodepen /> },
+  { href: "https://soundcloud.com/eljamez", text: "SoundCloud", icon: <FaSoundcloud /> },
+];
+
+const linkDelays = ["delay-[420ms]", "delay-[520ms]", "delay-[620ms]"];
+
+const socialDelays = [
+  "delay-[750ms]",
+  "delay-[820ms]",
+  "delay-[890ms]",
+  "delay-[960ms]",
+  "delay-[1030ms]",
 ];
 
 export default function HomePage4() {
   return (
-    <div className="w-full h-auto sm:h-full min-h-screen bg-slate-900 text-slate-100 flex flex-col p-4 sm:p-8 gap-4">
-      <div className="flex flex-col flex-1">
-        <h1 className="text-[3rem] sm:text-[5rem] md:text-[6rem] font-bold">
+    <div className="w-full min-h-screen bg-slate-900 text-slate-100 flex flex-col p-4 sm:p-8">
+      <div className="flex flex-col flex-1 max-w-4xl w-full">
+        <h1 className="text-[2.75rem] sm:text-[4rem] md:text-[5.5rem] font-bold leading-tight mb-4 animate-slide-up-fade delay-[0ms]">
           Hello <span className="text-green-500">I&apos;m James</span>
         </h1>
-        <h2 className="text-[1rem] sm:text-[2rem] md:text-[3rem] mb-8">
-          I&apos;m a Senior Software Engineer based in Ojai, CA. I enjoy writing
-          code, creating music, and making apps that people like to use.
+        <h2 className="text-base sm:text-lg md:text-xl mb-8 text-slate-300 font-light leading-relaxed animate-slide-up-fade delay-[150ms]">
+          Senior Software Engineer based in Ojai, CA. I write code, make music,
+          and build apps that people like to use.
         </h2>
-        <ul className="flex flex-col gap-4 text-xl sm:text-4xl sm:p-8 p-4 bg-slate-800 rounded-lg">
-          {links.map((link) => (
-            <li key={link.href}>
+        <ul className="flex flex-col gap-3 sm:gap-4 text-xl sm:text-3xl sm:p-6 p-4 bg-slate-800 rounded-lg animate-slide-up-fade delay-[300ms]">
+          {links.map((link, i) => (
+            <li key={link.href} className={`animate-slide-up-fade ${linkDelays[i]}`}>
               <a
                 href={link.href}
                 target="_blank"
-                className="hover:text-green-500 group transition-all flex sm:gap-6 gap-4 items-center"
+                className="hover:text-green-500 group transition-all duration-200 flex sm:gap-5 gap-3 items-center hover:translate-x-1"
               >
-                <span className="group-hover:rotate-180 transition-transform sm:w-10 sm:h-10 w-8 h-8 flex items-center justify-center">
+                <span className="group-hover:rotate-180 transition-transform duration-300 sm:w-9 sm:h-9 w-7 h-7 flex items-center justify-center flex-shrink-0">
                   {link.icon}
                 </span>
                 <span>{link.text}</span>
-                <span className="text-slate-400 text-sm sm:text-3xl">
+                <span className="text-slate-400 text-sm sm:text-base transition-all duration-200 group-hover:text-slate-300">
                   {link.description}
                 </span>
               </a>
             </li>
           ))}
         </ul>
-      </div>
 
-      <div className="fixed bottom-6 md:bottom-0 left-6 md:left-0 md:relative flex gap-8 text-lg sm:text-xl flex-1 md:items-end items-center">
-        {socialLinks.map((link) => (
-          <a
-            key={link.href}
-            href={link.href}
-            className="hover:text-green-500 transition-all flex gap-2 items-center"
-          >
-            {link.icon}
-            <span className="hidden md:inline">{link.text}</span>
-          </a>
-        ))}
+        <div className="flex flex-wrap gap-5 sm:gap-8 text-sm sm:text-base mt-auto pt-8 pb-2">
+          {socialLinks.map((link, i) => (
+            <a
+              key={link.href}
+              href={link.href}
+              target="_blank"
+              rel="noopener noreferrer"
+              className={`hover:text-green-500 transition-all duration-200 flex gap-2 items-center hover:scale-110 text-slate-400 animate-slide-up-fade ${socialDelays[i]}`}
+            >
+              {link.icon}
+              <span className="hidden sm:inline">{link.text}</span>
+            </a>
+          ))}
+        </div>
       </div>
     </div>
   );

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -40,9 +40,27 @@ const config: Config = {
           from: { opacity: "0" },
           to: { opacity: "1" },
         },
+        slideUpFade: {
+          from: { opacity: "0", transform: "translateY(20px)" },
+          to: { opacity: "1", transform: "translateY(0)" },
+        },
+        shake: {
+          "0%, 100%": { transform: "translateX(0)" },
+          "20%": { transform: "translateX(-8px)" },
+          "40%": { transform: "translateX(8px)" },
+          "60%": { transform: "translateX(-5px)" },
+          "80%": { transform: "translateX(5px)" },
+        },
+        scaleIn: {
+          from: { opacity: "0", transform: "scale(0.94)" },
+          to: { opacity: "1", transform: "scale(1)" },
+        },
       },
       animation: {
         fadeIn: "fadeIn 1s ease-out forwards",
+        "slide-up-fade": "slideUpFade 0.6s cubic-bezier(0.22, 1, 0.36, 1) both",
+        shake: "shake 0.5s ease-in-out",
+        "scale-in": "scaleIn 0.4s cubic-bezier(0.22, 1, 0.36, 1) both",
       },
     },
   },


### PR DESCRIPTION
## Summary

- Staggered entrance animations on HomePage4 — h1 → h2 → link card → each link → social links, using `slideUpFade` with `animation-fill-mode: both` and CSS delay stagger
- ProjectCard hover: card lifts (`scale-[1.02]`), image zooms (`scale-110` in clipped wrapper), sidebar shifts color
- `FadeInSection` gains a `delay` prop; Work page project cards cascade in with 120ms stagger
- About page: bio + skills sections wrapped in FadeInSection, SkillPills get hover scale/color
- Contact form: spinning `Loader2` during submit, `animate-scale-in` success, `animate-shake` error
- `prefers-reduced-motion: reduce` block in globals.css collapses all durations to `0.01ms`
- Fixed homepage typography hierarchy — description and link descriptions now clearly subordinate to h1
- Constrained homepage content to `max-w-4xl`; social links moved to normal flow (was `fixed` overlay on mobile)
- Header removed per preference; social links remain at bottom of homepage

## Test plan

- [ ] Entrance animations play on hard refresh of homepage
- [ ] Hover states work on ProjectCards, SkillPills, and homepage links
- [ ] Work page cards stagger in on scroll
- [ ] Contact form shows spinner → success/error feedback
- [ ] `prefers-reduced-motion` users see instant state changes (no animation)
- [ ] Social links visible at bottom of homepage on mobile + desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)